### PR TITLE
added option -h for help 

### DIFF
--- a/lib/rails_refactor.rb
+++ b/lib/rails_refactor.rb
@@ -181,7 +181,7 @@ elsif ARGV[0] == "test"
                           "DummiesController", "HelloWorldController")
     end
   end
-else
+elsif ARGV[0] == '-h'
   puts "Usage:"
   puts "  rails_refactor rename DummyController NewController"
   puts "  rails_refactor rename DummyController.my_action new_action"


### PR DESCRIPTION
Without this, the rails_refactor usage details always appears when running any ruby/rails related operation as it's an executable.
